### PR TITLE
feat: 🎸 Added `debug` option, made rules parser debuggable

### DIFF
--- a/src/Grammars/Custom.ts
+++ b/src/Grammars/Custom.ts
@@ -20,6 +20,7 @@
 
 import { TokenError } from '../TokenError';
 import { IRule, Parser as _Parser, IToken, findRuleByName } from '../Parser';
+import { IGrammarParserOptions } from './types';
 
 namespace BNF {
   export const RULES: IRule[] = [
@@ -184,7 +185,7 @@ namespace BNF {
     }
   ];
 
-  export const parser = new _Parser(RULES, {});
+  export const defaultParser = new _Parser(RULES, { debug: false });
 
   const preDecorationRE = /^(!|&)/;
   const decorationRE = /(\?|\+|\*)$/;
@@ -389,7 +390,7 @@ namespace BNF {
     tmpRules.push(rule);
   }
 
-  export function getRules(source: string): IRule[] {
+  export function getRules(source: string, parser: _Parser = defaultParser): IRule[] {
     let ast = parser.getAST(source);
 
     if (!ast) throw new Error('Could not parse ' + source);
@@ -431,13 +432,14 @@ namespace BNF {
     return tmpRules;
   }
 
-  export function Transform(source: TemplateStringsArray): IRule[] {
-    return getRules(source.join(''));
+  export function Transform(source: TemplateStringsArray, subParser: _Parser = defaultParser): IRule[] {
+    return getRules(source.join(''), subParser);
   }
 
   export class Parser extends _Parser {
-    constructor(source: string, options) {
-      super(getRules(source), options);
+    constructor(source: string, options?: Partial<IGrammarParserOptions>) {
+      const subParser = options && options.debugRulesParser === true ? new _Parser(BNF.RULES, { debug: true }) : defaultParser;
+      super(getRules(source, subParser), options);
     }
     emitSource(): string {
       return emit(this);

--- a/src/Grammars/W3CEBNF.ts
+++ b/src/Grammars/W3CEBNF.ts
@@ -19,6 +19,7 @@
 // Comment	::=	'/*' ( [^*] | '*'+ [^*/] )* '*'* '*/'
 
 import { IRule, Parser as _Parser, IToken, findRuleByName } from '../Parser';
+import { IGrammarParserOptions } from './types';
 
 namespace BNF {
   export const RULES: IRule[] = [
@@ -155,7 +156,7 @@ namespace BNF {
     }
   ];
 
-  export const parser = new _Parser(RULES, {});
+  export const defaultParser = new _Parser(RULES, { debug: false });
 
   const preDecorationRE = /^(!|&)/;
   const decorationRE = /(\?|\+|\*)$/;
@@ -314,7 +315,7 @@ namespace BNF {
     tmpRules.push(rule);
   }
 
-  export function getRules(source: string): IRule[] {
+  export function getRules(source: string, parser: _Parser = defaultParser): IRule[] {
     let ast = parser.getAST(source);
 
     if (!ast) throw new Error('Could not parse ' + source);
@@ -333,13 +334,14 @@ namespace BNF {
     return tmpRules;
   }
 
-  export function Transform(source: TemplateStringsArray): IRule[] {
-    return getRules(source.join(''));
+  export function Transform(source: TemplateStringsArray, subParser: _Parser = defaultParser): IRule[] {
+    return getRules(source.join(''), subParser);
   }
 
   export class Parser extends _Parser {
-    constructor(source: string, options) {
-      super(getRules(source), options);
+    constructor(source: string, options?: Partial<IGrammarParserOptions>) {
+      const subParser = options && options.debugRulesParser === true ? new _Parser(BNF.RULES, { debug: true }) : defaultParser;
+      super(getRules(source, subParser), options);
     }
 
     emitSource(): string {

--- a/src/Grammars/types.ts
+++ b/src/Grammars/types.ts
@@ -1,0 +1,5 @@
+import { IParserOptions } from "../Parser";
+
+export interface IGrammarParserOptions extends IParserOptions {
+  debugRulesParser: boolean;
+}

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -124,14 +124,19 @@ function stripRules(token: IToken, re: RegExp) {
 export interface IDictionary<T> {
   [s: string]: T;
 }
+export interface IParserOptions {
+  keepUpperRules: boolean;
+  debug: boolean;
+}
 
 const ignoreMissingRules = ['EOF'];
 
 export class Parser {
-  debug = false;
+  private readonly debug;
 
   cachedRules: IDictionary<IRule> = {};
-  constructor(public grammarRules: IRule[], public options) {
+  constructor(public grammarRules: IRule[], public options?: Partial<IParserOptions>) {
+    this.debug = options ? options.debug === true : false;
     let errors = [];
 
     let neededRules: string[] = [];

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -27,8 +27,6 @@ source = path.resolve(process.cwd(), source);
 
 let sourceCode = fs.readFileSync(source).toString() + '\n';
 
-Grammars.Custom.parser.debug = false;
-
 let RULES = Grammars.Custom.getRules(sourceCode);
 
 console.log(`*/

--- a/test/BNF.spec.ts
+++ b/test/BNF.spec.ts
@@ -8,10 +8,6 @@ let inspect = require('util').inspect;
 let lexer = Grammars.BNF.RULES;
 let parser = new Parser(Grammars.BNF.RULES, {});
 
-// printBNF(parser);
-
-parser.debug = true;
-
 describe('Parse BNF', () => {
   let lisp = `
     <lisp-document>  ::= <s_expression> <lisp-document> | <RULE_WHITESPACE> | <s_expression> <EOF> | <EOF>
@@ -29,12 +25,12 @@ describe('Parse BNF', () => {
   let lispParser: Parser;
 
   it('creates a LISP parser', () => {
-    lispParser = new Grammars.BNF.Parser(lisp, {});
+    lispParser = new Grammars.BNF.Parser(lisp);
 
     printBNF(lispParser);
   });
 
-  lispParser = new Grammars.BNF.Parser(lisp, {});
+  lispParser = new Grammars.BNF.Parser(lisp);
 
   testParseToken(lispParser, 'test');
   testParseToken(lispParser, '(test a)');
@@ -61,12 +57,12 @@ describe('Parse custom calculator', () => {
   let calcuParser: Parser;
 
   it('creates a calculator parser', () => {
-    calcuParser = new Grammars.BNF.Parser(calc, {});
+    calcuParser = new Grammars.BNF.Parser(calc, {debug: false});
 
     printBNF(calcuParser);
   });
 
-  calcuParser = new Grammars.BNF.Parser(calc, {});
+  calcuParser = new Grammars.BNF.Parser(calc, {debug: false});
 
   testParseToken(calcuParser, '1');
   testParseToken(calcuParser, '0');

--- a/test/JSON.spec.ts
+++ b/test/JSON.spec.ts
@@ -51,9 +51,7 @@ describe('JSON', () => {
   describe('Grammars.W3C parses JSON grammar', function() {
     let RULES = Grammars.W3C.getRules(grammar);
 
-    let parser = new Parser(RULES, {});
-
-    // printBNF(parser);
+    let parser = new Parser(RULES, {debug: true});
 
     testParseToken(parser, JSON.stringify(true));
     testParseToken(parser, JSON.stringify(false));
@@ -65,15 +63,12 @@ describe('JSON', () => {
     testParseToken(parser, JSON.stringify(-10));
     testParseToken(parser, JSON.stringify(-10.1));
 
-    parser.debug = true;
     testParseToken(parser, JSON.stringify(10.1e123));
-    parser.debug = false;
 
     testParseToken(parser, JSON.stringify({}));
     testParseToken(parser, JSON.stringify({ a: true }));
     testParseToken(parser, JSON.stringify({ a: false }));
 
-    parser.debug = true;
     testParseToken(
       parser,
       JSON.stringify({
@@ -83,7 +78,6 @@ describe('JSON', () => {
         list: [1, 2, 3, true]
       })
     );
-    parser.debug = false;
 
     testParseToken(parser, JSON.stringify([]));
     testParseToken(parser, JSON.stringify([{}]));

--- a/test/JSONRecovery.spec.ts
+++ b/test/JSONRecovery.spec.ts
@@ -44,7 +44,7 @@ describe('JSON 2', () => {
     let parser: Parser;
 
     it('create parser', () => {
-      printBNF(Grammars.Custom.parser);
+      printBNF(Grammars.Custom.defaultParser);
       // console.dir(Grammars.Custom.getRules(grammar));
     });
   });


### PR DESCRIPTION
`debug` is now an option instead of a property, allowing to use it during construction. Grammar parsers can use a base parser with the `debug` option by using the `debugRulesParser` option. This allows the lib to be more easily debuggable.