### PR TITLE
Generate entire array when compiling grammar.

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -33,4 +33,4 @@ let RULES = Grammars.Custom.getRules(sourceCode);
 
 console.log(`*/
 
-module.exports = ${util.inspect(RULES, false, 20, false)};`);
+module.exports = ${util.inspect(RULES, { depth: 20, maxArrayLength: null })};`);


### PR DESCRIPTION
The `bin` compiler uses `util.inspect` to dump an executable JavaScript file. However, `inspect` per default only prints the first 100 entries of an array. This PR removes that limit.

Discussion in #17.