### PR TITLE
Updated StringLiteral in custom grammar to use RegExps for faster performance

### DIFF
--- a/src/Grammars/Custom.ts
+++ b/src/Grammars/Custom.ts
@@ -19,7 +19,7 @@
 // Comment	::=	'/*' ( [^*] | '*'+ [^*/] )* '*'* '*/'
 
 import { TokenError } from '../TokenError';
-import { IRule, Parser as _Parser, IToken, findRuleByName } from '../Parser';
+import { IRule, Parser as _Parser, IToken, escapeRegExp, findRuleByName } from '../Parser';
 import { IGrammarParserOptions } from './types';
 
 namespace BNF {
@@ -305,8 +305,16 @@ namespace BNF {
           bnfSeq.push(preDecoration + name + decoration);
           break;
         case 'NCName':
-        case 'StringLiteral':
           bnfSeq.push(preDecoration + x.text + decoration);
+          break;
+        case 'StringLiteral':
+          if (decoration || preDecoration || !/^['"/()a-zA-Z0-9&_.:=,+*\-\^\\]+$/.test(x.text)) {
+             bnfSeq.push(preDecoration + x.text + decoration);
+          } else {
+             for (const c of x.text.slice(1, -1)) {
+                bnfSeq.push(new RegExp(escapeRegExp(c)));
+             }
+          }
           break;
         case 'CharCode':
         case 'CharClass':

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -54,7 +54,7 @@ export function readToken(txt: string, expr: RegExp): IToken {
   return null;
 }
 
-function escapeRegExp(str) {
+export function escapeRegExp(str) {
   return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
 }
 


### PR DESCRIPTION
This PR is for https://github.com/lys-lang/node-ebnf/issues/20. It increases speed performance by using Regexps for StringLiteral's.