### PR TITLE
Fix Attributes/ignore case on SubItems for StringLiterals.

### DIFF
--- a/src/Grammars/Custom.ts
+++ b/src/Grammars/Custom.ts
@@ -366,7 +366,7 @@ namespace BNF {
       });
     }
 
-    let bnf = token.children.filter(x => x.type == 'SequenceOrDifference').map(s => getSubItems(tmpRules, s, name, parentAttributes ? parentAttributes: attributes));
+    let bnf = token.children.filter(x => x.type == 'SequenceOrDifference').map(s => getSubItems(tmpRules, s, name, parentAttributes ? parentAttributes : attributes));
 
     let rule: IRule = {
       name,

--- a/src/Grammars/Custom.ts
+++ b/src/Grammars/Custom.ts
@@ -300,7 +300,7 @@ namespace BNF {
         case 'SubItem':
           let name = '%' + (parentName + subitems++);
 
-          createRule(tmpRules, x, name);
+          createRule(tmpRules, x, name, parentAttributes);
 
           bnfSeq.push(preDecoration + name + decoration);
           break;

--- a/src/Grammars/Custom.ts
+++ b/src/Grammars/Custom.ts
@@ -271,7 +271,7 @@ namespace BNF {
     );
   }
 
-  function getSubItems(tmpRules, seq: IToken, parentName: string) {
+  function getSubItems(tmpRules, seq: IToken, parentName: string, parentAttributes: any) {
     let anterior = null;
     let bnfSeq = [];
 
@@ -312,7 +312,12 @@ namespace BNF {
              bnfSeq.push(preDecoration + x.text + decoration);
           } else {
              for (const c of x.text.slice(1, -1)) {
-                bnfSeq.push(new RegExp(escapeRegExp(c)));
+                if (parentAttributes && parentAttributes["ignoreCase"] == "true" && /[a-zA-Z]/.test(c)) {
+                   bnfSeq.push(new RegExp("[" + c.toUpperCase() + c.toLowerCase() + "]"));
+                }
+                else {
+                   bnfSeq.push(new RegExp(escapeRegExp(c)));
+                }
              }
           }
           break;
@@ -332,7 +337,6 @@ namespace BNF {
             bnfSeq.push(convertRegex(x.text));
           }
           break;
-
         case 'PrimaryPreDecoration':
         case 'PrimaryDecoration':
           break;
@@ -346,9 +350,7 @@ namespace BNF {
     return bnfSeq;
   }
 
-  function createRule(tmpRules: any[], token: IToken, name: string) {
-    let bnf = token.children.filter(x => x.type == 'SequenceOrDifference').map(s => getSubItems(tmpRules, s, name));
-
+  function createRule(tmpRules: any[], token: IToken, name: string, parentAttributes: any = undefined) {
     let attrNode = token.children.filter(x => x.type == 'Attributes')[0];
 
     let attributes: any = {};
@@ -363,6 +365,8 @@ namespace BNF {
         }
       });
     }
+
+    let bnf = token.children.filter(x => x.type == 'SequenceOrDifference').map(s => getSubItems(tmpRules, s, name, parentAttributes ? parentAttributes: attributes));
 
     let rule: IRule = {
       name,

--- a/test/StringLiteral.spec.ts
+++ b/test/StringLiteral.spec.ts
@@ -1,0 +1,77 @@
+declare var describe, it, require;
+
+import { Grammars, Parser } from '../dist';
+import { findRuleByName } from '../dist/Parser';
+import { testParseToken, testParseTokenFailsafe } from './TestHelpers';
+
+let inspect = require('util').inspect;
+let expect = require('expect');
+
+let grammar = `
+
+Document          ::= Keyword1 | Keyword2
+
+Keyword1          ::= 'And' | 'Or'
+Keyword2          ::= 'Not' | 'Is' {ignoreCase=true}
+
+`;
+
+describe('String Literals', () => {
+  describe('Parse JSON', () => {
+    let parser: Parser;
+
+    it('create parser', () => {
+      parser = new Parser(Grammars.Custom.RULES, {});
+      testParseToken(parser, grammar);
+    });
+  });
+
+  describe('Grammars.Custom parses JSON grammar', function() {
+    let RULES = Grammars.Custom.getRules(grammar);
+    console.log('JSON:\n' + inspect(RULES, false, 20, true));
+    let parser = new Parser(RULES, {});
+
+    it('string literal case sensitive rule', () => {
+       let rule = findRuleByName("Keyword1", parser);
+
+       console.log(rule.bnf[0]);
+
+       expect(rule.bnf[0][0]).toEqual(RegExp('A'));
+       expect(rule.bnf[0][1]).toEqual(RegExp('n'));
+       expect(rule.bnf[0][2]).toEqual(RegExp('d'));
+
+       console.log(rule.bnf[1]);
+
+       expect(rule.bnf[1][0]).toEqual(RegExp('O'));
+       expect(rule.bnf[1][1]).toEqual(RegExp('r'));
+    });
+
+    testParseTokenFailsafe(parser, 'And');
+    testParseTokenFailsafe(parser, 'Or');
+
+    it('string literal case sensitive rule - OR', () => {
+       expect(parser.getAST('OR')).toEqual(null);
+    });
+
+    it('string literal case insensitive rule', () => {
+       let rule = findRuleByName("Keyword2", parser);
+
+       console.log(rule.bnf[0]);
+
+       expect(rule.bnf[0][0]).toEqual(RegExp('[Nn]'));
+       expect(rule.bnf[0][1]).toEqual(RegExp('[Oo]'));
+       expect(rule.bnf[0][2]).toEqual(RegExp('[Tt]'));
+
+       console.log(rule.bnf[1]);
+
+       expect(rule.bnf[1][0]).toEqual(RegExp('[Ii]'));
+       expect(rule.bnf[1][1]).toEqual(RegExp('[Ss]'));
+    });
+
+    testParseTokenFailsafe(parser, 'is');
+    testParseTokenFailsafe(parser, 'IS');
+    testParseTokenFailsafe(parser, 'NoT');
+    testParseTokenFailsafe(parser, 'not');
+    testParseTokenFailsafe(parser, 'NOT');
+  });
+});


### PR DESCRIPTION
This fixes the last PR, by correctly passing in `parentAttributes` into `createRule` for SubItems.