### PR TITLE
Fix pinning, and improve TS typing

### DIFF
--- a/src/Grammars/BNF.ts
+++ b/src/Grammars/BNF.ts
@@ -217,7 +217,7 @@ namespace BNF {
 
     let rules = findChildrenByType(ast, 'rule');
 
-    let ret = rules.map(rule => {
+    let ret = rules.map((rule) : IRule => {
       let name = findChildrenByType(rule, 'rule-name')[0].text;
 
       let expressions = findChildrenByType(rule, 'firstExpression').concat(findChildrenByType(rule, 'otherExpression'));

--- a/src/Grammars/Custom.ts
+++ b/src/Grammars/Custom.ts
@@ -271,7 +271,7 @@ namespace BNF {
     );
   }
 
-  function getSubItems(tmpRules, seq: IToken, parentName: string, parentAttributes: any) {
+  function getSubItems(tmpRules : IRule[], seq: IToken, parentName: string, parentAttributes: any) {
     let anterior = null;
     let bnfSeq = [];
 
@@ -290,7 +290,7 @@ namespace BNF {
         preDecoration = anterior.text;
       }
 
-      let pinned = preDecoration == '~';
+      let pinned = preDecoration == '~' ? 1 : undefined;
 
       if (pinned) {
         preDecoration = '';
@@ -324,7 +324,7 @@ namespace BNF {
         case 'CharCode':
         case 'CharClass':
           if (decoration || preDecoration) {
-            let newRule = {
+            let newRule : IRule = {
               name: '%' + (parentName + subitems++),
               bnf: [[convertRegex(x.text)]],
               pinned
@@ -350,7 +350,7 @@ namespace BNF {
     return bnfSeq;
   }
 
-  function createRule(tmpRules: any[], token: IToken, name: string, parentAttributes: any = undefined) {
+  function createRule(tmpRules: IRule[], token: IToken, name: string, parentAttributes: any = undefined) {
     let attrNode = token.children.filter(x => x.type == 'Attributes')[0];
 
     let attributes: any = {};
@@ -430,7 +430,7 @@ namespace BNF {
 
     implicitWs = attributes['ws'] == 'implicit';
 
-    let tmpRules = [];
+    let tmpRules : IRule[] = [];
 
     ast.children.filter(x => x.type == 'Production').map((x: any) => {
       let name = x.children.filter(x => x.type == 'NCName')[0].text;

--- a/src/Grammars/W3CEBNF.ts
+++ b/src/Grammars/W3CEBNF.ts
@@ -293,7 +293,7 @@ namespace BNF {
     return bnfSeq;
   }
 
-  function createRule(tmpRules: any[], token: IToken, name: string) {
+  function createRule(tmpRules: IRule[], token: IToken, name: string) {
     let bnf = token.children.filter(x => x.type == 'SequenceOrDifference').map(s => getSubItems(tmpRules, s, name));
 
     let rule: IRule = {
@@ -324,7 +324,7 @@ namespace BNF {
       throw ast.errors[0];
     }
 
-    let tmpRules = [];
+    let tmpRules : IRule[] = [];
 
     ast.children.filter(x => x.type == 'Production').map((x: any) => {
       let name = x.children.filter(x => x.type == 'NCName')[0].text;


### PR DESCRIPTION
Fixes https://github.com/lys-lang/node-ebnf/issues/27

The improved explicit typing would help prevent similar issues in future.

**Unit tests:** 247 passing (338ms)

Somebody should confirm this is the appropriate value to assign:

```
let pinned = preDecoration == '~' ? 1 : undefined;
```
Initial tests show that it appears to work, but the use of bool is ambiguous when it is expecting a numeric value. In the very least, the FALSE case (undefined) works appropriately. I can't say the same for the alternate case.